### PR TITLE
Add two window hooks

### DIFF
--- a/docs/useWindowEvent.md
+++ b/docs/useWindowEvent.md
@@ -1,0 +1,37 @@
+---
+id: use-windowevent
+title: useWindowEvent
+sidebar_label: useWindowEvent
+---
+
+## HookResponse
+
+None
+
+### Properties
+
+None
+
+## useWindowEvent
+
+React hook that will subscribe an event in the `window` when the component
+is mounted and will unsubscribe the event when the component unmount.
+
+### Parameters
+
+-   `eventName` **[string][1]** Window event name.
+-   `func` **[function][2]** Function that will be fire when the event is triggered.
+-   `funcDeps` **[array][3]** Function dependecies since we are using `useCallback` in `func`.
+
+Returns nothing.
+
+**Meta**
+
+-   **author**: Felipe Nolleto Nascimento &lt;felipenolletonascimento@gmail.com>
+-   **license**: https&#x3A;//tldrlegal.com/license/mit-license MIT
+
+[1]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+
+[2]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function
+
+[3]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array

--- a/docs/useWindowSize.md
+++ b/docs/useWindowSize.md
@@ -1,0 +1,36 @@
+---
+id: use-windowsize
+title: useWindowSize
+sidebar_label: useWindowSize
+---
+
+## HookResponse
+
+Type: [object][1]
+
+### Properties
+
+-   `width` **[number][2]** Current window width.
+-   `height` **[number][2]** Current window height.
+
+## useWindowSize
+
+React hook to get the current window size (width, height).
+This hook will listen the resize window event to always keep the size up to date.
+
+### Parameters
+
+None.
+
+Returns **[HookResponse][3]** Hook response to be used within your component like props
+
+**Meta**
+
+-   **author**: Felipe Nolleto Nascimento &lt;felipenolletonascimento@gmail.com>
+-   **license**: https&#x3A;//tldrlegal.com/license/mit-license MIT
+
+[1]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+
+[2]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+
+[3]: #hookresponse

--- a/src/hooks/useWindowEvent.js
+++ b/src/hooks/useWindowEvent.js
@@ -1,0 +1,28 @@
+import { useCallback, useEffect } from 'react'
+
+/**
+ * @typedef  {object}           HookResponse
+ */
+
+/**
+ * @function
+ * @name useWindowEvent
+ * @description React hook that will subscribe an event in the `window` when the component
+ * is mounted and will unsubscribe the event when the component unmount.
+ * @author Felipe Nolleto Nascimento <felipenolletonascimento@gmail.com>
+ * @license https://tldrlegal.com/license/mit-license MIT
+ *
+ * @param  {string}  eventName - Window event name.
+ * @param  {function}  func - Function that will be fire when the event is triggered.
+ * @param  {array}  funcDeps - Function dependecies since we are using `useCallback` in `func`.
+ *
+ * @return {HookResponse} Nothing.
+ */
+export default function useWindowEvent(eventName, func, funcDeps = []) {
+  const newFunc = useCallback(func, funcDeps);
+
+  useEffect(() => {
+    window.addEventListener(eventName, newFunc);
+    return () => window.removeEventListener(eventName, newFunc);
+  }, []);
+};

--- a/src/hooks/useWindowSize.js
+++ b/src/hooks/useWindowSize.js
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import useWindowEvent from '@hooks/useWindowEvent';
+
+const getWindowWidth = () => window.innerWidth;
+const getWindowHeight = () => window.innerHeight;
+
+/**
+ * @typedef  {object}           HookResponse
+ * @property {number}           width - Current window width.
+ * @property {number}           height - Current window height.
+ */
+
+/**
+ * @function
+ * @name useWindowSize
+ * @description React hook to get the current window size (width, height).
+ * This hook will listen the resize window event to always keep the size up to date.
+ * @author Felipe Nolleto Nascimento <felipenolletonascimento@gmail.com>
+ * @license https://tldrlegal.com/license/mit-license MIT
+ *
+ * @return {HookResponse} Hook response to be used within your component like props
+ */
+export default function useWindowSize() {
+  const [width, setWidth] = useState(getWindowWidth());
+  const [height, setHeight] = useState(getWindowHeight());
+
+  useWindowEvent('resize', () => {
+    setWidth(getWindowWidth());
+    setHeight(getWindowHeight());
+  });
+
+  return { width, height };
+}

--- a/tests/hooks/useWindowEvent.test.js
+++ b/tests/hooks/useWindowEvent.test.js
@@ -1,0 +1,41 @@
+import { renderHook } from 'react-hooks-testing-library';
+import useWindowEvent from '@hooks/useWindowEvent';
+
+describe('useWindowEvent()', () => {
+  const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+  const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+  const eventName = 'resize';
+  const callback = jest.fn();
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = renderHook(() => useWindowEvent(eventName, callback));
+  });
+
+  describe('When component is mounted', () => {
+    test('subscribes event in window', () => {
+      expect(addEventListenerSpy).toBeCalledWith(eventName, callback);
+    });
+  });
+
+  describe('When component is unmounted', () => {
+    beforeEach(() => {
+      wrapper.unmount();
+    })
+
+    test('unsubscribes event in window', () => {
+      expect(removeEventListenerSpy).toBeCalledWith(eventName, callback);
+    });
+  });
+
+  describe('When event is triggered', () => {
+    beforeEach(() => {
+      callback.mockClear();
+      window.dispatchEvent(new Event(eventName));
+    })
+
+    test('calls callback function', () => {
+      expect(callback).toBeCalled();
+    });
+  });
+})

--- a/tests/hooks/useWindowSize.test.js
+++ b/tests/hooks/useWindowSize.test.js
@@ -1,0 +1,38 @@
+import { act, renderHook } from 'react-hooks-testing-library';
+
+import useWindowSize from '@hooks/useWindowSize';
+
+const resize = (width, height) => {
+  window.innerWidth = width || window.innerWidth;
+  window.innerHeight = height || window.innerHeight;
+  window.dispatchEvent(new Event('resize'));
+};
+
+describe('useWindowSize()', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    resize(800, 600);
+    wrapper = renderHook(() => useWindowSize());
+  });
+
+  describe('When component is mounted', () => {
+    test('returns the current window size', () => {
+      const { result } = wrapper;
+      expect(result.current).toEqual({ width: 800, height: 600 });
+    });
+  });
+
+  describe('When window size changes', () => {
+    beforeEach(() => {
+      act(() => {
+        resize(1024, 768);
+      });
+    });
+
+    test('returns the new window size', () => {
+      const { result } = wrapper;
+      expect(result.current).toEqual({ width: 1024, height: 768 });
+    });
+  });
+});


### PR DESCRIPTION
Create two hooks:

- `useWindowEvent` - React hook that will subscribe to an event in the `window` when the component is mounted and will unsubscribe the event when the component unmount.
- `useWindowSize` - React hook to get the current window size (`width`, `height`).
This hook will listen to the resize window event to always keep the size up to date.